### PR TITLE
Force order

### DIFF
--- a/src/components/Rules/Rules/index.js
+++ b/src/components/Rules/Rules/index.js
@@ -29,13 +29,14 @@ export default class Rules extends React.Component {
   }
 
   addRule(rule) {
+    let new_rules = JSON.parse(JSON.stringify(this.state.rules)); //deep clone to update changes
     rule['id'] = this.state.max_index + 1;
     this.setState({max_index: this.state.max_index + 1})
-    rule['index'] = 0;
+    rule['index'] = rulesUtils.calculateNewRuleIndex(new_rules, rule.contagionRisk);
     rule['created'] = true;
-    let new_rules = JSON.parse(JSON.stringify(this.state.rules)); //deep clone to update changes
-    new_rules = rulesUtils.updateIndexesFromAddition(new_rules);
+    new_rules = rulesUtils.updateIndexesFromAddition(new_rules, rule.index);
     new_rules.unshift(rule);
+    new_rules = rulesUtils.forceHighMidLowOrder(new_rules);
     this.setState({
       rules: new_rules
     });
@@ -55,11 +56,12 @@ export default class Rules extends React.Component {
     if (result.destination.index === result.source.index) {
       return;
     }
-    const new_rules = rulesUtils.reorder(
+    let new_rules = rulesUtils.reorder(
       this.state.rules,
       result.source.index,
       result.destination.index
     );
+    new_rules = rulesUtils.forceHighMidLowOrder(new_rules);
     this.setState({ rules: new_rules });
     this.updateSavingButton(new_rules);
   }

--- a/src/components/Rules/RulesContainer/index.js
+++ b/src/components/Rules/RulesContainer/index.js
@@ -38,7 +38,27 @@ export default function RulesContainer({rules, addRule, saveChanges, canSaveChan
 						<Droppable droppableId="list">
 							{provided => (
 								<div ref={provided.innerRef} {...provided.droppableProps}>
-									<RulesList rules={state.rules} deleteRule={deleteRule} />
+									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Alto')} deleteRule={deleteRule} />
+									{provided.placeholder}
+								</div>
+							)}
+						</Droppable>
+					</DragDropContext>
+					<DragDropContext onDragEnd={onDragEnd}>
+						<Droppable droppableId="list">
+							{provided => (
+								<div ref={provided.innerRef} {...provided.droppableProps}>
+									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Medio')} deleteRule={deleteRule} />
+									{provided.placeholder}
+								</div>
+							)}
+						</Droppable>
+					</DragDropContext>
+					<DragDropContext onDragEnd={onDragEnd}>
+						<Droppable droppableId="list">
+							{provided => (
+								<div ref={provided.innerRef} {...provided.droppableProps}>
+									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Bajo')} deleteRule={deleteRule} />
 									{provided.placeholder}
 								</div>
 							)}

--- a/src/utils/rulesUtils.js
+++ b/src/utils/rulesUtils.js
@@ -1,6 +1,9 @@
 export function calculateNewRuleIndex(new_rules, contagionRisk) {
+	if (contagionRisk === 'Alto') {
+		return 0;
+	}
 	for (var i = 0; i < new_rules.length; i++) {
-		if (new_rules[i].contagionRisk === contagionRisk){
+		if (new_rules[i].contagionRisk === contagionRisk || (contagionRisk === 'Medio' && new_rules[i].contagionRisk === 'Bajo')){
 			return i;
 		}
 	}
@@ -37,27 +40,15 @@ export function reorder(list, startIndex, endIndex) {
 	return result;
 }
 
+function cmpRulesRisk(r1, r2) {
+	if (r1.contagionRisk === r2.contagionRisk) {
+		return r1.index < r2.index ? -1 : 1;
+	}
+	return (r1.contagionRisk === 'Alto' || r2.contagionRisk === 'Bajo') ? -1 : 1;
+}
+
 export function forceHighMidLowOrder(rules) {
-	const q_per_risk = {'Alto': 0, 'Medio': 0, 'Bajo': 0};
-	rules.forEach(rule => {
-		q_per_risk[rule.contagionRisk] += 1;
-	});
-	const current_index_per_risk = {'Alto': 0, 'Medio': q_per_risk['Alto'], 'Bajo': q_per_risk['Alto'] + q_per_risk['Medio']};
-	rules.forEach(rule => {
-		if (rule['contagionRisk'] === 'Alto') {
-			rule['index'] = current_index_per_risk['Alto'];
-			current_index_per_risk['Alto'] += 1;
-		}
-		if (rule['contagionRisk'] === 'Medio') {
-			rule['index'] = current_index_per_risk['Medio'];
-			current_index_per_risk['Medio'] += 1;
-		}
-		if (rule['contagionRisk'] === 'Bajo') {
-			rule['index'] = current_index_per_risk['Bajo'];
-			current_index_per_risk['Bajo'] += 1;
-		}
-	});
-	return rules.sort((r1, r2) => {return r1.index < r2.index ? -1 : 1});
+	return rules.sort(cmpRulesRisk);
 }
 
 export function areRulesEqual(new_rules, saved_rules) {

--- a/src/utils/rulesUtils.js
+++ b/src/utils/rulesUtils.js
@@ -41,10 +41,15 @@ export function reorder(list, startIndex, endIndex) {
 }
 
 function cmpRulesRisk(r1, r2) {
+	const riskPriorities = {
+		'Alto': 1,
+		'Medio': 2,
+		'Bajo': 3
+	}
 	if (r1.contagionRisk === r2.contagionRisk) {
 		return r1.index < r2.index ? -1 : 1;
 	}
-	return (r1.contagionRisk === 'Alto' || r2.contagionRisk === 'Bajo') ? -1 : 1;
+	return riskPriorities[r1.contagionRisk] < riskPriorities[r2.contagionRisk] ? -1 : 1;
 }
 
 export function forceHighMidLowOrder(rules) {

--- a/src/utils/rulesUtils.js
+++ b/src/utils/rulesUtils.js
@@ -1,6 +1,17 @@
-export function updateIndexesFromAddition(new_rules) {
+export function calculateNewRuleIndex(new_rules, contagionRisk) {
+	for (var i = 0; i < new_rules.length; i++) {
+		if (new_rules[i].contagionRisk === contagionRisk){
+			return i;
+		}
+	}
+	return new_rules.length;
+}
+
+export function updateIndexesFromAddition(new_rules, indexAdded) {
 	new_rules.forEach(rule => {
-		rule['index'] = rule['index'] + 1;
+		if (rule['index'] >= indexAdded) {
+			rule['index'] = rule['index'] + 1;
+		}
 	});
 	return new_rules;
 }
@@ -24,6 +35,29 @@ export function reorder(list, startIndex, endIndex) {
 	});
 
 	return result;
+}
+
+export function forceHighMidLowOrder(rules) {
+	const q_per_risk = {'Alto': 0, 'Medio': 0, 'Bajo': 0};
+	rules.forEach(rule => {
+		q_per_risk[rule.contagionRisk] += 1;
+	});
+	const current_index_per_risk = {'Alto': 0, 'Medio': q_per_risk['Alto'], 'Bajo': q_per_risk['Alto'] + q_per_risk['Medio']};
+	rules.forEach(rule => {
+		if (rule['contagionRisk'] === 'Alto') {
+			rule['index'] = current_index_per_risk['Alto'];
+			current_index_per_risk['Alto'] += 1;
+		}
+		if (rule['contagionRisk'] === 'Medio') {
+			rule['index'] = current_index_per_risk['Medio'];
+			current_index_per_risk['Medio'] += 1;
+		}
+		if (rule['contagionRisk'] === 'Bajo') {
+			rule['index'] = current_index_per_risk['Bajo'];
+			current_index_per_risk['Bajo'] += 1;
+		}
+	});
+	return rules.sort((r1, r2) => {return r1.index < r2.index ? -1 : 1});
 }
 
 export function areRulesEqual(new_rules, saved_rules) {


### PR DESCRIPTION
- Agrego un orden forzado, primero riesgo Alto, después Medio y por último Bajo. 
- No se pueden reordenar las tarjetas entre los diferentes grupos, pero si entre tarjetas del mismos riesgo para poder hacer optimizaciones de performance 
- Al crear una tarjeta aparece primera en el grupo del mismo riesgo. 
- Al borrar tarjetas se reordenan todas.

[Demo](https://drive.google.com/file/d/1Z3aw7pc7dQZvKvfZo3skMr3Sm0dc3uAR/view?usp=sharing)