### PR TITLE
remove force order

### DIFF
--- a/src/components/Rules/Rules/index.js
+++ b/src/components/Rules/Rules/index.js
@@ -29,14 +29,13 @@ export default class Rules extends React.Component {
   }
 
   addRule(rule) {
-    let new_rules = JSON.parse(JSON.stringify(this.state.rules)); //deep clone to update changes
     rule['id'] = this.state.max_index + 1;
     this.setState({max_index: this.state.max_index + 1})
-    rule['index'] = rulesUtils.calculateNewRuleIndex(new_rules, rule.contagionRisk);
+    rule['index'] = 0;
     rule['created'] = true;
-    new_rules = rulesUtils.updateIndexesFromAddition(new_rules, rule.index);
+    let new_rules = JSON.parse(JSON.stringify(this.state.rules)); //deep clone to update changes
+    new_rules = rulesUtils.updateIndexesFromAddition(new_rules);
     new_rules.unshift(rule);
-    new_rules = rulesUtils.forceHighMidLowOrder(new_rules);
     this.setState({
       rules: new_rules
     });
@@ -56,12 +55,11 @@ export default class Rules extends React.Component {
     if (result.destination.index === result.source.index) {
       return;
     }
-    let new_rules = rulesUtils.reorder(
+    const new_rules = rulesUtils.reorder(
       this.state.rules,
       result.source.index,
       result.destination.index
     );
-    new_rules = rulesUtils.forceHighMidLowOrder(new_rules);
     this.setState({ rules: new_rules });
     this.updateSavingButton(new_rules);
   }

--- a/src/components/Rules/RulesContainer/index.js
+++ b/src/components/Rules/RulesContainer/index.js
@@ -38,27 +38,7 @@ export default function RulesContainer({rules, addRule, saveChanges, canSaveChan
 						<Droppable droppableId="list">
 							{provided => (
 								<div ref={provided.innerRef} {...provided.droppableProps}>
-									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Alto')} deleteRule={deleteRule} />
-									{provided.placeholder}
-								</div>
-							)}
-						</Droppable>
-					</DragDropContext>
-					<DragDropContext onDragEnd={onDragEnd}>
-						<Droppable droppableId="list">
-							{provided => (
-								<div ref={provided.innerRef} {...provided.droppableProps}>
-									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Medio')} deleteRule={deleteRule} />
-									{provided.placeholder}
-								</div>
-							)}
-						</Droppable>
-					</DragDropContext>
-					<DragDropContext onDragEnd={onDragEnd}>
-						<Droppable droppableId="list">
-							{provided => (
-								<div ref={provided.innerRef} {...provided.droppableProps}>
-									<RulesList rules={state.rules.filter(rule => rule.contagionRisk === 'Bajo')} deleteRule={deleteRule} />
+									<RulesList rules={state.rules} deleteRule={deleteRule} />
 									{provided.placeholder}
 								</div>
 							)}

--- a/src/utils/rulesUtils.js
+++ b/src/utils/rulesUtils.js
@@ -1,20 +1,6 @@
-export function calculateNewRuleIndex(new_rules, contagionRisk) {
-	if (contagionRisk === 'Alto') {
-		return 0;
-	}
-	for (var i = 0; i < new_rules.length; i++) {
-		if (new_rules[i].contagionRisk === contagionRisk || (contagionRisk === 'Medio' && new_rules[i].contagionRisk === 'Bajo')){
-			return i;
-		}
-	}
-	return new_rules.length;
-}
-
-export function updateIndexesFromAddition(new_rules, indexAdded) {
+export function updateIndexesFromAddition(new_rules) {
 	new_rules.forEach(rule => {
-		if (rule['index'] >= indexAdded) {
-			rule['index'] = rule['index'] + 1;
-		}
+		rule['index'] = rule['index'] + 1;
 	});
 	return new_rules;
 }
@@ -38,22 +24,6 @@ export function reorder(list, startIndex, endIndex) {
 	});
 
 	return result;
-}
-
-function cmpRulesRisk(r1, r2) {
-	const riskPriorities = {
-		'Alto': 1,
-		'Medio': 2,
-		'Bajo': 3
-	}
-	if (r1.contagionRisk === r2.contagionRisk) {
-		return r1.index < r2.index ? -1 : 1;
-	}
-	return riskPriorities[r1.contagionRisk] < riskPriorities[r2.contagionRisk] ? -1 : 1;
-}
-
-export function forceHighMidLowOrder(rules) {
-	return rules.sort(cmpRulesRisk);
 }
 
 export function areRulesEqual(new_rules, saved_rules) {


### PR DESCRIPTION
Orden forzado anterior al PR:
![image](https://user-images.githubusercontent.com/22566107/116424989-572a3f00-a818-11eb-9f73-4fcacfcf50d2.png)

Ahora no hay un orden forzado:
![image](https://user-images.githubusercontent.com/22566107/116425042-63160100-a818-11eb-99b7-c425c3a586ec.png)

Creo una regla con riesgo medio, aparece arriba (independientemente del riesgo de la regla, se crea primero y se actualizan todos los indices para hacer lugar):
![image](https://user-images.githubusercontent.com/22566107/116425792-efc0bf00-a818-11eb-95e4-fbe571363e9d.png)

Elimino la regla de riesgo bajo, actualiza bien los indices de las reglas siguientes:
![image](https://user-images.githubusercontent.com/22566107/116425711-dfa8df80-a818-11eb-8db1-54f56b7ef044.png)